### PR TITLE
Fix Axios error when parsing emls

### DIFF
--- a/backend/schemas/eml.py
+++ b/backend/schemas/eml.py
@@ -36,12 +36,12 @@ class Body(APIModel):
 
 class Received(APIModel):
     by: list[str] | None = None
-    date: datetime
+    date: str = ""
     for_: list[str] | None = Field(default=None, alias="for")
     from_: list[str] | None = Field(default=None, alias="from")
     src: str
     with_: str | None = Field(default=None, alias="with")
-    delay: int
+    delay: int | None = None
 
 
 class Header(APIModel):


### PR DESCRIPTION
This PR addresses issues with parsing and handling date fields in email headers, particularly in the 'received' headers. The main changes are in the `backend/factories/eml.py` file, where we've updated the `_normalize_received_date` and `_normalize_received` functions to handle invalid or missing dates more gracefully. The `_normalize_received_date` function now always returns a string for the date field, using an empty string as a fallback when date parsing fails. This ensures consistency in the data type returned to the frontend.

For example, when sending some emails exported from Apple Mail and a handful of other clients, submitted emls would upload, then immediately return with `AxiosError: Request failed with status code 500`. This is caused because some emls would have invalid dates on the first hop from spam emails. 

Modified `Received` model in `backend/schemas/eml.py` to expect a string for the date field with a default empty string value. This change aligns the schema with the new date handling logic in the factory functions.

The `_normalize_received` function has been improved to handle potential parsing errors when calculating delays between received timestamps. It now sets the delay to 0 if date parsing fails, preventing errors from propagating to other parts of the application.

This allows the app to handle a wider range of malformed or unusual email headers without crashing or producing invalid data structures. The frontend should now receive consistent data types for date fields, resolving previous display and processing issues.